### PR TITLE
requirements.txt: pin httpx version to 0.27.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-httpx
+httpx==0.27.2
 pycryptodomex


### PR DESCRIPTION
After version 0.27.2, the `proxies` argument of AsyncClient is removed. This is a quick fix. In the long run we should migrate to the latest verson of httpx.